### PR TITLE
call to addcommand with New, lower-cased ldflag vars

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,47 +5,46 @@ release:
   github:
     owner: jpillora
     name: opts-cli
-  name_template: '{{.Tag}}'
+  name_template: "{{.Tag}}"
   # disable: true
 
 builds:
-- 
-  binary: opts-cli
-  env:
-  - CGO_ENABLED=0
-  goos:
-  - linux
-  - darwin
-  - windows
-  goarch:
-  - amd64
-  - "386"
-  ignore:
-  - goos: darwin
-    goarch: 386
-  main: .
-  ldflags:
-  - -s -w -X main.Version={{.Version}} -X main.Commit={{.Commit}} -X main.Date={{.Date}}
+  - binary: opts-cli
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - "386"
+    ignore:
+      - goos: darwin
+        goarch: 386
+    main: .
+    ldflags:
+      - -s -w -X main.version={{.version}} -X main.commit={{.commit}} -X main.date={{.date}}
 
 archive:
   replacements:
     386: i386
     amd64: x86_64
   format_overrides:
-  - goos: windows
-    format: zip
+    - goos: windows
+      format: zip
   files:
-  - licence*
-  - LICENCE*
-  - license*
-  - LICENSE*
-  - readme*
-  - README*
-  - changelog*
-  - CHANGELOG*
+    - licence*
+    - LICENCE*
+    - license*
+    - LICENSE*
+    - readme*
+    - README*
+    - changelog*
+    - CHANGELOG*
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 snapshot:
   name_template: "{{ .Tag }}-next"
@@ -54,5 +53,5 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"

--- a/internal/init/init.go
+++ b/internal/init/init.go
@@ -1,4 +1,4 @@
-package initopts
+package init
 
 import (
 	"errors"
@@ -21,12 +21,11 @@ type initOpts struct {
 	Directory      string `opts:"help=output directory"`
 }
 
-func Register(parent opts.Opts) {
-	in := initOpts{
+func New() opts.Opts {
+	return opts.New(&initOpts{
 		SrcControlHost: "github.com",
 		Directory:      ".",
-	}
-	parent.AddCommand(opts.New(&in).Name("init"))
+	})
 }
 
 func (in *initOpts) Run() error {
@@ -45,10 +44,6 @@ func (in *initOpts) Run() error {
 			return err
 		}
 	}
-	// if err := f.Close(); err != nil {
-	// 	log.Fatal(err)
-	// }
-
 	data := struct {
 		Module  string
 		Command string
@@ -78,9 +73,6 @@ func (in *initOpts) Run() error {
 		fmt.Printf("#%v\n", fi.Path)
 		pa := filepath.Join(in.Directory, path.Dir(fi.Path))
 		_ = os.MkdirAll(pa, 0755)
-		// if err != nil {
-		// 	return err
-		// }
 		pa = filepath.Join(pa, path.Base(fi.Path))
 		ofi, err := os.OpenFile(pa, os.O_RDWR|os.O_CREATE, 0664)
 		if err != nil {
@@ -124,9 +116,9 @@ import (
 )
 
 var (
-	Version string = "dev"
-	Date    string = "na"
-	Commit  string = "na"
+	version string = "dev"
+	date    string = "na"
+	commit  string = "na"
 )
 
 type root struct {
@@ -138,7 +130,7 @@ func main() {
 	r.parsedOpts = opts.New(&r).Name("{{.Name}}").
 		EmbedGlobalFlagSet().
 		Complete().
-		Version(Version).
+		Version(version).
 		Call(initopts.Register).
 		Parse()
 	err := r.parsedOpts.Run()
@@ -149,7 +141,7 @@ func main() {
 }
 
 func (rt *root) Run() {
-	fmt.Printf("Version: %s\nDate: %s\nCommit: %s\n", Version, Date, Commit)
+	fmt.Printf("version: %s\ndate: %s\ncommit: %s\n", version, date, commit)
 	fmt.Println(rt.parsedOpts.Help())
 }
 `,
@@ -208,7 +200,7 @@ builds:
     goarch: 386
   main: .
   ldflags:
-  - -s -w -X main.Version={{"{{"}}.Version}} -X main.Commit={{"{{"}}.Commit}} -X main.Date={{"{{"}}.Date}}
+  - -s -w -X main.version={{"{{"}}.version}} -X main.commit={{"{{"}}.commit}} -X main.date={{"{{"}}.date}}
 
 archive:
   replacements:

--- a/main.go
+++ b/main.go
@@ -5,35 +5,36 @@ import (
 	"os"
 
 	"github.com/jpillora/opts"
-	"github.com/jpillora/opts-cli/internal/initopts"
+	initPkg "github.com/jpillora/opts-cli/internal/init"
 )
 
 var (
-	Version string = "dev"
-	Date    string = "na"
-	Commit  string = "na"
+	version = "dev"
+	date    = "na"
+	commit  = "na"
 )
 
 type root struct {
-	parsedOpts opts.ParsedOpts
+	help string
 }
 
 func main() {
 	r := root{}
-	r.parsedOpts = opts.New(&r).
+	o := opts.New(&r).
 		EmbedGlobalFlagSet().
 		Complete().
-		Version(Version).
-		Call(initopts.Register).
+		Version(version).
+		AddCommand(initPkg.New()).
 		Parse()
-	err := r.parsedOpts.Run()
+	r.help = o.Help()
+	err := o.Run()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "run error %v\n", err)
 		os.Exit(2)
 	}
 }
 
-func (rt *root) Run() {
-	fmt.Printf("Version: %s\nDate: %s\nCommit: %s\n", Version, Date, Commit)
-	fmt.Println(rt.parsedOpts.Help())
+func (r *root) Run() {
+	fmt.Printf("version: %s\ndate: %s\ncommit: %s\n", version, date, commit)
+	fmt.Println(r.help)
 }


### PR DESCRIPTION
If we used this `New() opts.Opts` pattern, we wouldn't need `Call`

Was thinking, the only thing you need from parent opts is the `AddCommand` method

(Writing the demo, and I think I'll use `New() opts.Opts`)